### PR TITLE
Solve thread race condition in structure generation

### DIFF
--- a/common/src/main/java/io/github/frqnny/mostructures/structure/ModStructure.java
+++ b/common/src/main/java/io/github/frqnny/mostructures/structure/ModStructure.java
@@ -94,7 +94,8 @@ public class ModStructure extends Structure {
 
             for (int curChunkX = pos.x - 2; curChunkX <= pos.x + 2; curChunkX++) {
                 for (int curChunkZ = pos.z - 2; curChunkZ <= pos.z + 2; curChunkZ++) {
-                    int height = chunkGenerator.getHeight((curChunkX << 4) + 7, (curChunkZ << 4) + 7, Heightmap.Type.WORLD_SURFACE_WG, world, noiseConfig);
+                    // Use getBaseHeight to avoid deadlocks with neighboring chunks during worldgen.
+                     int height = chunkGenerator.getBaseHeight((curChunkX << 4) + 7, (curChunkZ << 4) + 7, Heightmap.Type.WORLD_SURFACE_WG, world, noiseConfig);
                     maxTerrainHeight = Math.max(maxTerrainHeight, height);
                     minTerrainHeight = Math.min(minTerrainHeight, height);
                 }


### PR DESCRIPTION
Change neighboring chunk calculation to use [getBaseHeight](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/generator/ChunkGenerator.html#getBaseHeight(org.bukkit.generator.WorldInfo,java.util.Random,int,int,org.bukkit.HeightMap)) 
https://github.com/frqnny/mostructures/issues/83

Note that this will no longer account for blocks on top of the surface gen, but should be fine for the applications of this function (will defer to mod author).